### PR TITLE
Fix handlebars critical AST injection (pin to 4.7.9)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3846,9 +3846,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
   "devDependencies": {
     "prettier": "^3.6.2",
     "typescript": "^5.9.3"
+  },
+  "overrides": {
+    "handlebars": "4.7.9"
   }
 }


### PR DESCRIPTION
## Security remediation: handlebars critical AST injection

Pins the transitive **handlebars** dependency to **4.7.9** via an npm `overrides` entry in the root `package.json`.

### Alerts resolved (8 open Dependabot alerts, root `package-lock.json`)
| Alert | Severity | GHSA |
|-------|----------|------|
| #57 | **Critical** | GHSA-2w6w-674q-4c4q (JS Injection via AST Type Confusion) |
| #58, #55, #54, #56 | High | |
| #60, #53 | Medium | |
| #59 | Low | |

handlebars is pulled transitively (`@langchain/community` -> `@langchain/classic` -> `handlebars`), so Dependabot did not open an auto-PR. The `overrides` entry forces the patched 4.7.9 across the tree.

### Validation
- `npm run build` — GREEN (tsc across `packages-v1/*` workspaces)
- `npm audit` critical count: 1 -> 0

Patch-level bump (4.7.8 -> 4.7.9), no API changes.